### PR TITLE
Fix suppression search to fetch all pages

### DIFF
--- a/src/app/api/suppressions/route.ts
+++ b/src/app/api/suppressions/route.ts
@@ -104,10 +104,9 @@ export async function GET(request: NextRequest) {
         console.log(`[GET /api/suppressions] Direct lookup succeeded!`);
         suppressions = [directLookupResult];
       } else {
-        // Direct lookup failed - email might be partial match
-        // For performance, only fetch first page instead of all 10k+ suppressions
-        console.log(`[GET /api/suppressions] Direct lookup failed, fetching first page for partial matches`);
-        suppressions = await listAndFilterSuppressions(searchTerm, true); // limit to first page
+        // Direct lookup failed - fetch all pages to find partial matches
+        console.log(`[GET /api/suppressions] Direct lookup failed, fetching all pages for partial matches`);
+        suppressions = await listAndFilterSuppressions(searchTerm, false); // fetch all pages
       }
     } else {
       // No search term, list first page only

--- a/src/app/api/suppressions/route.ts
+++ b/src/app/api/suppressions/route.ts
@@ -109,8 +109,8 @@ export async function GET(request: NextRequest) {
         suppressions = await listAndFilterSuppressions(searchTerm, false); // fetch all pages
       }
     } else {
-      // No search term, list first page only
-      suppressions = await listAndFilterSuppressions("", true);
+      // No search term, fetch all pages
+      suppressions = await listAndFilterSuppressions("", false);
     }
 
     console.log(`[GET /api/suppressions] Response: ${suppressions.length} suppressions found`);


### PR DESCRIPTION
### Summary
This PR fixes the suppression search functionality to fetch all pages of suppressions from the Emailit API, instead of being limited to only the first page (25 records).

### Problem
When searching for a suppressed email, users were only seeing results from the first page of the suppression list (limited to ~25 records). Any suppressed emails beyond that first page were invisible to the search, making it impossible to find suppressions that existed further in the paginated list.

### Solution
Updated the `GET /api/suppressions` route to pass `false` for the `limitToFirstPage` parameter in all code paths, ensuring `listAndFilterSuppressions` fetches all available pages from the Emailit API rather than stopping after the first page.

### Key Changes
- **Partial match search**: When a direct lookup by email fails, the fallback now fetches all pages instead of only the first page to find partial matches.
- **No search term (list all)**: When listing suppressions without a search term, all pages are now fetched instead of just the first page.
- Both changes pass `false` to `listAndFilterSuppressions`, enabling full pagination traversal across the entire suppression list.


---

<a href="https://builder.io/app/projects/c33c56238a2f4bc98fc24910c94b51f9/golden-pod-9yilwrri"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://c33c56238a2f4bc98fc24910c94b51f9-golden-pod-9yilwrri_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=c33c56238a2f4bc98fc24910c94b51f9&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 42`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c33c56238a2f4bc98fc24910c94b51f9</projectId>-->
<!--<branchName>golden-pod-9yilwrri</branchName>-->